### PR TITLE
CodeQL -  Unrecognized command or argument '-p:UseSharedCompilation=false'

### DIFF
--- a/.github/workflows/db.yml
+++ b/.github/workflows/db.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
-      - name: Restore
+      - name: Restore Packages
         run: dotnet restore ./src/Services/IdentityServer/src/AW.Services.IdentityServer.Database.Build/AW.Services.IdentityServer.Database.Build.csproj
 
       - name: Initialize CodeQL

--- a/.github/workflows/db.yml
+++ b/.github/workflows/db.yml
@@ -31,9 +31,19 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
-      - name: Build and run unit tests
+      - name: Restore
         run: dotnet restore ./src/Services/IdentityServer/src/AW.Services.IdentityServer.Database.Build/AW.Services.IdentityServer.Database.Build.csproj
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: csharp
 
       - name: Build and run unit tests
         run: |
           dotnet build ./src/Services/IdentityServer/src/AW.Services.IdentityServer.Database.Build/AW.Services.IdentityServer.Database.Build.csproj
+    
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
+        with:
+          category: "/language:csharp"

--- a/src/Services/IdentityServer/src/AW.Services.IdentityServer.Database.Build/AW.Services.IdentityServer.Database.Build.csproj
+++ b/src/Services/IdentityServer/src/AW.Services.IdentityServer.Database.Build/AW.Services.IdentityServer.Database.Build.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="MSBuild.Sdk.SqlProj/2.2.0">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <SqlServerVersion>Sql150</SqlServerVersion>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="..\AW.Services.IdentityServer.Database\**\Tables\*.sql" />

--- a/src/Services/IdentityServer/src/AW.Services.IdentityServer.Database.Build/AW.Services.IdentityServer.Database.Build.csproj
+++ b/src/Services/IdentityServer/src/AW.Services.IdentityServer.Database.Build/AW.Services.IdentityServer.Database.Build.csproj
@@ -1,6 +1,10 @@
 <Project Sdk="MSBuild.Sdk.SqlProj/2.2.0">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+    <DeployOnPublish>False</DeployOnPublish>
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <IsPackable>False</IsPackable>
+    <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
   </PropertyGroup>
   <ItemGroup>
     <Content Include="..\AW.Services.IdentityServer.Database\**\Tables\*.sql" />


### PR DESCRIPTION
Wrap `MSBuild.Sdk.SqlProj/2.2.0` with CodeQL trace reproduces the error `Unrecognized command or argument '-p:UseSharedCompilation=false'`

NOTE: once the build successfully runs, you will STILL get an error: `No code found during the build.`
- this is expected as no further csharp code is extracted in this scenario. A real world scenario would have a build that also included some additional C# and had the SqlProj linked in for various reasons to have a successful build.